### PR TITLE
Add documentation and DocC support

### DIFF
--- a/Example/HelloWorld.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/HelloWorld.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SwiftDocCPlugin",
+        "repositoryURL": "https://github.com/apple/swift-docc-plugin",
+        "state": {
+          "branch": null,
+          "revision": "26ac5758409154cc448d7ab82389c520fa8a8247",
+          "version": "1.3.0"
+        }
+      },
+      {
+        "package": "SymbolKit",
+        "repositoryURL": "https://github.com/apple/swift-docc-symbolkit",
+        "state": {
+          "branch": null,
+          "revision": "b45d1f2ed151d057b54504d653e0da5552844e34",
+          "version": "1.0.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -19,8 +19,7 @@ let package = Package(
             targets: ["Aptabase"]),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Aptabase/Aptabase.swift
+++ b/Sources/Aptabase/Aptabase.swift
@@ -32,7 +32,7 @@ public class Aptabase: NSObject {
         "SH": ""
     ]
 
-    let dateFormatter: DateFormatter = {
+    private let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
         formatter.locale = Locale(identifier: "en_US")

--- a/Sources/Aptabase/Aptabase.swift
+++ b/Sources/Aptabase/Aptabase.swift
@@ -1,14 +1,16 @@
 import Foundation
 
+/// Initialization options for the client.
 public final class InitOptions: NSObject {
     let host: String?
 
+    /// - Parameter host: The custom host to use. If none provided will use Aptabase's servers.
     @objc public init(host: String? = nil) {
         self.host = host
     }
 }
 
-// The Aptabase client used to track events
+/// The Aptabase client used to track events.
 public class Aptabase: NSObject {
     private static var sdkVersion = "aptabase-swift@0.2.0";
     
@@ -20,6 +22,7 @@ public class Aptabase: NSObject {
     private var lastTouched = Date()
     private var apiURL: URL?
 
+    /// The shared client instance.
     @objc public static let shared = Aptabase()
     
     private var hosts = [
@@ -37,7 +40,10 @@ public class Aptabase: NSObject {
         return formatter
     }()
     
-    // Initializes the client with given App Key
+    /// Initializes the client with given App Key.
+    /// - Parameters:
+    ///   - appKey: The App Key to use.
+    ///   - options: Optional initialization options.
     public func initialize(appKey: String, with options: InitOptions? = nil) {
         let parts = appKey.components(separatedBy: "-")
         if parts.count != 3 || hosts[parts[1]] == nil {
@@ -50,19 +56,32 @@ public class Aptabase: NSObject {
         env = EnvironmentInfo.get()
     }
     
-    // Track an event using given properties
+    /// Track an event using given properties.
+    /// - Parameters:
+    ///   - eventName: The name of the event to track.
+    ///   - props: Additional given properties.
     public func trackEvent(_ eventName: String, with props: [String: Value] = [:]) {
         sendEvent(eventName, with: props)
     }
     
+    /// Initializes the client with given App Key.
+    /// - Parameter appKey: The App Key to use.
     @objc public func initialize(appKey: String) {
         initialize(appKey: appKey, with: nil)
     }
-    
+
+    /// Initializes the client with given App Key.
+    /// - Parameters:
+    ///   - appKey: The App Key to use.
+    ///   - options: Optional initialization options.
     @objc public func initialize(appKey: String, options: InitOptions?) {
         initialize(appKey: appKey, with: options)
     }
     
+    /// Track an event using given properties.
+    /// - Parameters:
+    ///   - eventName: The name of the event to track.
+    ///   - props: Additional given properties.
     @objc public func trackEvent(_ eventName: String, with props: [String: Any] = [:]) {
         sendEvent(eventName, with: props)
     }

--- a/Sources/Aptabase/EnvironmentInfo.swift
+++ b/Sources/Aptabase/EnvironmentInfo.swift
@@ -8,7 +8,7 @@ import WatchKit
 import TVUIKit
 #endif
 
-public struct EnvironmentInfo {
+struct EnvironmentInfo {
     var isDebug = false
     var osName = ""
     var osVersion = ""
@@ -16,7 +16,7 @@ public struct EnvironmentInfo {
     var appVersion = ""
     var appBuildNumber = ""
     
-    public static func get() -> EnvironmentInfo {
+    static func get() -> EnvironmentInfo {
         let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
         let appBuildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
         

--- a/Sources/Aptabase/Value.swift
+++ b/Sources/Aptabase/Value.swift
@@ -1,3 +1,4 @@
+/// Protocol for supported property values.
 public protocol Value {}
 extension Int: Value {}
 extension Double: Value {}


### PR DESCRIPTION
This PR adds basic code documentation for all public types, mostly based on the docs that were already present in the code.

I also made some of the types that seem to be meant to only be used internally by the package non-public. If this was incorrect I can change back.

Additionally it adds DocC (https://developer.apple.com/documentation/docc) support, for easy generation of documentation based on the documentation comments.

I was going to also add the generated HTML/CSS documentation in a /docs folder that can be backed by Github Pages, but I'm waiting with that to see what the interest is from the package author. If this is wanted I can add it to this PR, or in a follow up PR.