### PR TITLE
Fix compile issues on Swift 5.6

### DIFF
--- a/Sources/Aptabase/Aptabase.swift
+++ b/Sources/Aptabase/Aptabase.swift
@@ -88,12 +88,12 @@ public class Aptabase: NSObject {
     
     private func sendEvent(_ eventName: String, with props: [String: Any] = [:]) {
         DispatchQueue(label: "com.aptabase.aptabase").async { [self] in
-            guard let appKey, let env, let apiURL else {
+            guard let appKey = appKey, let env = env, let apiURL = apiURL else {
                 return
             }
             
             let now = Date()
-            if (lastTouched.distance(to: now) > sessionTimeout) {
+            if lastTouched.distance(to: now) > sessionTimeout {
                 sessionId = UUID()
             }
             
@@ -129,7 +129,7 @@ public class Aptabase: NSObject {
             request.addValue("application/json", forHTTPHeaderField: "Content-Type")
             
             let task = URLSession.shared.dataTask(with: request) { data, response, error in
-                guard let data, error == nil else {
+                guard let data = data, error == nil else {
                     debugPrint(error?.localizedDescription ?? "unknown error")
                     return
                 }
@@ -148,7 +148,7 @@ public class Aptabase: NSObject {
     private func getApiUrl(_ region: String, _ host: String?) -> URL? {
         guard var baseURL = hosts[region] else { return nil }
         if region == "SH" {
-            guard let host else {
+            guard let host = host else {
                 debugPrint("Host parameter must be defined when using Self-Hosted App Key. Tracking will be disabled.")
                 return nil
             }


### PR DESCRIPTION
The package manifest and Podspec indicates that the package is supporting Swift 5.5 and up, but the code uses optional binding syntax introduced first in Swift 5.7 - causing compilation errors on versions below that.

`error: variable binding in a condition requires an initializer`

An alternative to this PR is to keep the more modern syntax for optional binding, but then we might need to bump the minimum supported Swift version to Swift 5.7. 

I have not tested Swift 5.5 (don't have easy access to the toolchain), but I hope/think it should work fine there, but it can be good to test.