### PR TITLE
Detect macOS Catalyst

### DIFF
--- a/Aptabase.podspec
+++ b/Aptabase.podspec
@@ -10,6 +10,6 @@ Pod::Spec.new do |s|
     s.osx.deployment_target     = "10.15"
     s.watchos.deployment_target = "6.0"
     s.tvos.deployment_target    = "13.0"
-    s.swift_version             = '5.5'
+    s.swift_version             = '5.6'
     s.source_files              = 'Sources/Aptabase/**/*'
   end

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/Aptabase/EnvironmentInfo.swift
+++ b/Sources/Aptabase/EnvironmentInfo.swift
@@ -41,6 +41,8 @@ struct EnvironmentInfo {
     private static var osName: String {
         #if os(macOS)
         "macOS"
+        #elseif targetEnvironment(macCatalyst)
+        "macOS (Catalyst)"
 #elseif os(iOS)
         if UIDevice.current.userInterfaceIdiom == .pad {
             return "iPadOS"
@@ -56,7 +58,7 @@ struct EnvironmentInfo {
     }
     
     private static var osVersion: String {
-        #if os(macOS)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         let os = ProcessInfo.processInfo.operatingSystemVersion
         return "\(os.majorVersion).\(os.minorVersion).\(os.patchVersion)"
         #elseif os(iOS)

--- a/Sources/Aptabase/EnvironmentInfo.swift
+++ b/Sources/Aptabase/EnvironmentInfo.swift
@@ -39,10 +39,8 @@ struct EnvironmentInfo {
     }
     
     private static var osName: String {
-        #if os(macOS)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         "macOS"
-        #elseif targetEnvironment(macCatalyst)
-        "macOS (Catalyst)"
 #elseif os(iOS)
         if UIDevice.current.userInterfaceIdiom == .pad {
             return "iPadOS"


### PR DESCRIPTION
Currently if the app is run on macOS as a Catalyst app (basically the iOS, i.e. UIKit instead of AppKit, version adapted to work on macOS) it is reported as iOS.

While this might be (at least somewhat) true in some technical sense, I feel that counting it as running on macOS better captures what is actually going on.