### PR TITLE
Small tweaks

### DIFF
--- a/Aptabase.podspec
+++ b/Aptabase.podspec
@@ -10,6 +10,6 @@ Pod::Spec.new do |s|
     s.osx.deployment_target     = "10.15"
     s.watchos.deployment_target = "6.0"
     s.tvos.deployment_target    = "13.0"
-    s.swift_version             = '5.6'
+    s.swift_version             = '5.7'
     s.source_files              = 'Sources/Aptabase/**/*'
   end

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,9 @@ let package = Package(
             name: "Aptabase",
             targets: ["Aptabase"]),
     ],
-    dependencies: [],
+    dependencies: [
+      .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0")
+    ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
@@ -33,9 +35,3 @@ let package = Package(
         )
     ]
 )
-
-
-#if swift(>=5.6)
-// Add the DocC plugin if possible.
-package.dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"))
-#endif

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ let package = Package(
     ...
     dependencies: [
         ...
-        .package(name: "Aptabase", url: "https://github.com/aptabase/aptabase-swift.git", from: "0.2.3"),
+        .package(name: "Aptabase", url: "https://github.com/aptabase/aptabase-swift.git", from: "0.3.3"),
     ],
     targets: [
         .target(
@@ -39,7 +39,7 @@ Use this [guide](https://developer.apple.com/documentation/xcode/adding-package-
 Aptabase is also available through CocoaPods. To install it, simply add the following line to your Podfile:
 
 ```ruby
-pod 'Aptabase', :git => 'https://github.com/aptabase/aptabase-swift.git', :tag => '0.2.3'
+pod 'Aptabase', :git => 'https://github.com/aptabase/aptabase-swift.git', :tag => '0.3.3'
 ```
 
 


### PR DESCRIPTION
Some various small tweaks:

- Remove workaround to add the DocC dependency before when Swift 5.5 was supported.
- Update package file to show that only Swift 5.7 and higher is supported.
- Small tweak to the README.