### PR TITLE
Support Device Model

### DIFF
--- a/Sources/Aptabase/AptabaseClient.swift
+++ b/Sources/Aptabase/AptabaseClient.swift
@@ -36,7 +36,8 @@ class AptabaseClient {
                             osVersion: env.osVersion,
                             appVersion: env.appVersion,
                             appBuildNumber: env.appBuildNumber,
-                            sdkVersion: AptabaseClient.sdkVersion
+                            sdkVersion: AptabaseClient.sdkVersion,
+                            deviceModel: env.deviceModel
                         ),
                         props: props)
         dispatcher.enqueue(evt)

--- a/Sources/Aptabase/EnvironmentInfo.swift
+++ b/Sources/Aptabase/EnvironmentInfo.swift
@@ -17,6 +17,7 @@ struct EnvironmentInfo {
     var locale = ""
     var appVersion = ""
     var appBuildNumber = ""
+    var deviceModel = ""
 
     static func current() -> EnvironmentInfo {
         let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
@@ -28,7 +29,8 @@ struct EnvironmentInfo {
             osVersion: osVersion,
             locale: Locale.current.languageCode ?? "",
             appVersion: appVersion ?? "",
-            appBuildNumber: appBuildNumber ?? ""
+            appBuildNumber: appBuildNumber ?? "",
+            deviceModel: deviceModel
         )
     }
 
@@ -70,5 +72,21 @@ struct EnvironmentInfo {
         #else
         ""
         #endif
+    }
+
+    private static var deviceModel: String {
+        if let simulatorModelIdentifier = ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] {
+            return simulatorModelIdentifier
+        } else {
+            var systemInfo = utsname()
+            uname(&systemInfo)
+
+            let identifier = withUnsafePointer(to: &systemInfo.machine) { ptr in
+                ptr.withMemoryRebound(to: CChar.self, capacity: 1) { machinePtr in
+                    String(cString: machinePtr)
+                }
+            }
+            return identifier
+        }
     }
 }

--- a/Sources/Aptabase/EnvironmentInfo.swift
+++ b/Sources/Aptabase/EnvironmentInfo.swift
@@ -79,14 +79,15 @@ struct EnvironmentInfo {
             return simulatorModelIdentifier
         } else {
             var systemInfo = utsname()
-            uname(&systemInfo)
-
-            let identifier = withUnsafePointer(to: &systemInfo.machine) { ptr in
-                ptr.withMemoryRebound(to: CChar.self, capacity: 1) { machinePtr in
-                    String(cString: machinePtr)
+            if uname(&systemInfo) == 0 {
+                let identifier = withUnsafePointer(to: &systemInfo.machine) { ptr in
+                    ptr.withMemoryRebound(to: CChar.self, capacity: 1) { machinePtr in
+                        String(cString: machinePtr)
+                    }
                 }
+                return identifier
             }
-            return identifier
+            return ""
         }
     }
 }

--- a/Sources/Aptabase/EventDispatcher.swift
+++ b/Sources/Aptabase/EventDispatcher.swift
@@ -15,6 +15,7 @@ struct Event: Encodable {
         var appVersion: String
         var appBuildNumber: String
         var sdkVersion: String
+        var deviceModel: String
     }
 }
 

--- a/Tests/AptabaseTests/EventDispatcherTests.swift
+++ b/Tests/AptabaseTests/EventDispatcherTests.swift
@@ -21,7 +21,8 @@ final class EventDispatcherTests: XCTestCase {
         isDebug: true,
         osName: "iOS",
         osVersion: "17.0",
-        appVersion: "1.0.0"
+        appVersion: "1.0.0",
+        deviceModel: "iPhone16,2"
     )
 
     override func setUp() {
@@ -90,7 +91,8 @@ final class EventDispatcherTests: XCTestCase {
                                                     osVersion: env.osVersion,
                                                     appVersion: env.appVersion,
                                                     appBuildNumber: env.appBuildNumber,
-                                                    sdkVersion: "aptabase-swift@0.0.0")
+                                                    sdkVersion: "aptabase-swift@0.0.0",
+                                                    deviceModel: env.deviceModel)
         )
     }
 }


### PR DESCRIPTION
Add device model information as part of environment info and system properties.

Related to https://github.com/aptabase/aptabase-swift/issues/20

The device model will be reported in the form of "iPhone16,2" (iPhone 15 Pro Max) and similar. This can be mapped to a corresponding model if needed, but that has to be kept up to date when new models are released - so I kept it in this form. That mapping can be done either on the client, or the server, or even the web UI.