### PR TITLE
fix: isDebug environment for multiple non RELEASE build configs

### DIFF
--- a/Sources/Aptabase/EnvironmentInfo.swift
+++ b/Sources/Aptabase/EnvironmentInfo.swift
@@ -35,10 +35,10 @@ struct EnvironmentInfo {
     }
 
     private static var isDebug: Bool {
-        #if DEBUG
-        true
-        #else
+        #if RELEASE
         false
+        #else
+        true
         #endif
     }
 


### PR DESCRIPTION
We are currently experiencing an issue where multiple non-DEBUG configurations, such as RELEASE, STAGING, or TEST, are being reported as RELEASE to Aptabase. 

It's common for developers to set up three environments: RELEASE, STAGING/TEST, and DEBUG. Typically, only one environment—RELEASE—is production-related, while the others are used for testing (DEBUG). Therefore, it would make sense to adjust the Aptabase environment logic so that it defaults to DEBUG when it is not RELEASE.