### PR TITLE
fix: events logged only as debug

### DIFF
--- a/Aptabase.podspec
+++ b/Aptabase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                      = 'Aptabase'
-    s.version                   = '0.3.10'
+    s.version                   = '0.3.11'
     s.summary                   = 'Swift SDK for Aptabase: Open Source, Privacy-First and Simple Analytics for Mobile, Desktop and Web Apps'
     s.homepage                  = 'https://aptabase.com'
     s.license                   = { :type => 'MIT', :file => 'LICENSE' }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.3.11
+
+* Reverts previous change which caused RELEASE data not to show up
+* Adds an option to explicitly set the tracking mode to Debug or Release. Not setting this option will fallback to the previous reading of environment value.
+
+- Setting to release
+`Aptabase.shared.initialize(appKey: "", options: InitOptions(trackingMode: .asRelease))`
+
+- Setting to debug
+`Aptabase.shared.initialize(appKey: "", options: InitOptions(trackingMode: .asDebug))`
+
+- Setting omitting the value, same as setting to `.readFromEnvironment`:
+`Aptabase.shared.initialize(appKey: "")`
+`Aptabase.shared.initialize(appKey: "", options: InitOptions(trackingMode: .readFromEnvironment))`
+
 ## 0.3.10
 
 * Fix isDebug environment for multiple non RELEASE build configs https://github.com/aptabase/aptabase-swift/pull/24

--- a/Examples/HelloWorldMac/HelloWorldMacApp.swift
+++ b/Examples/HelloWorldMac/HelloWorldMacApp.swift
@@ -4,7 +4,11 @@ import Aptabase
 @main
 struct HelloWorldMacApp: App {
     init() {
-        Aptabase.shared.initialize(appKey: "A-DEV-0000000000");
+        Aptabase.shared.initialize(
+            appKey: "A-DEV-0000000000", 
+            // optionally track events as release, avoiding the default environment variable
+            options: InitOptions(trackingMode: .asRelease) 
+        )
     }
     
     var body: some Scene {

--- a/Sources/Aptabase/Aptabase.swift
+++ b/Sources/Aptabase/Aptabase.swift
@@ -33,6 +33,10 @@ public class Aptabase: NSObject {
             return
         }
 
+        if let trackingMode = options?.trackingMode, trackingMode != .readFromEnvironment {
+            env.isDebug = trackingMode.isDebug
+        }
+
         client = AptabaseClient(appKey: appKey, baseUrl: baseUrl, env: env, options: options)
 
         let notifications = NotificationCenter.default

--- a/Sources/Aptabase/AptabaseClient.swift
+++ b/Sources/Aptabase/AptabaseClient.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 class AptabaseClient {
-    private static let sdkVersion = "aptabase-swift@0.3.10"
+    private static let sdkVersion = "aptabase-swift@0.3.11"
     // Session expires after 1 hour of inactivity
     private static let sessionTimeout: TimeInterval = 1 * 60 * 60
 

--- a/Sources/Aptabase/EnvironmentInfo.swift
+++ b/Sources/Aptabase/EnvironmentInfo.swift
@@ -35,10 +35,10 @@ struct EnvironmentInfo {
     }
 
     private static var isDebug: Bool {
-        #if RELEASE
-        false
-        #else
+        #if DEBUG
         true
+        #else
+        false
         #endif
     }
 

--- a/Sources/Aptabase/InitOptions.swift
+++ b/Sources/Aptabase/InitOptions.swift
@@ -4,12 +4,15 @@ import Foundation
 public final class InitOptions: NSObject {
     let host: String?
     let flushInterval: Double?
+    let trackingMode: TrackingMode
 
     /// - Parameters:
     ///   - host: The custom host to use. If none provided will use Aptabase's servers.
     ///   - flushInterval: Defines a custom interval for flushing events.
-    @objc public init(host: String? = nil, flushInterval: NSNumber? = nil) {
+    ///   - trackingMode: Use TrackingMode.asDebug for debug events, TrackingMode.asRelease for release events, or TrackingMode.readFromEnvironment to use the environment setting. Defaults to .readFromEnvironment if omitted.
+    @objc public init(host: String? = nil, flushInterval: NSNumber? = nil, trackingMode: TrackingMode = .readFromEnvironment) {
         self.host = host
         self.flushInterval = flushInterval?.doubleValue
+        self.trackingMode = trackingMode
     }
 }

--- a/Sources/Aptabase/TrackingMode.swift
+++ b/Sources/Aptabase/TrackingMode.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Represents the tracking mode (release/debug) for the client.
+@objc public class TrackingMode: NSObject {
+    @objc public static let asDebug = TrackingMode(rawValue: 0)
+    @objc public static let asRelease = TrackingMode(rawValue: 1)
+    @objc public static let readFromEnvironment = TrackingMode(rawValue: 2)
+    
+    private let rawValue: Int
+    
+    private init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+    
+    @objc public var isDebug: Bool {
+        return self.rawValue == 0
+    }
+    
+    @objc public var isRelease: Bool {
+        return self.rawValue == 1
+    }
+    
+    @objc public var isReadFromEnvironment: Bool {
+        return self.rawValue == 2
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/aptabase/aptabase-swift/issues/26

Reverts changes from https://github.com/aptabase/aptabase-swift/pull/24

Adds an option to explicitly set the tracking mode to Debug or Release. Not setting this option will fallback to the previous reading of environment value.

- Setting to release
`Aptabase.shared.initialize(appKey: "", options: InitOptions(trackingMode: .asRelease))`

- Setting to debug
`Aptabase.shared.initialize(appKey: "", options: InitOptions(trackingMode: .asDebug))`

- Omitting the value, same as setting to `.readFromEnvironment`:
`Aptabase.shared.initialize(appKey: "")`
`Aptabase.shared.initialize(appKey: "", options: InitOptions(trackingMode: .readFromEnvironment))`