### PR TITLE
Add an `async` `Aptabase.flush()`

### DIFF
--- a/Sources/Aptabase/Aptabase.swift
+++ b/Sources/Aptabase/Aptabase.swift
@@ -92,11 +92,16 @@ public class Aptabase: NSObject {
         enqueueEvent(eventName, with: codable)
     }
 
-    /// Forces all queued events to be sent to the server
+    /// Forces all queued events to be sent to the server asynchronously. Returns before the events have been sent.
     @objc public func flush() {
         Task {
             await self.client?.flush()
         }
+    }
+
+    /// Forces all queued events to be sent to the server. Returns after the events have been sent.
+    public func flush() async {
+        await self.client?.flush()
     }
 
     private func enqueueEvent(_ eventName: String, with props: [String: AnyCodableValue] = [:]) {

--- a/Sources/Aptabase/Aptabase.swift
+++ b/Sources/Aptabase/Aptabase.swift
@@ -101,7 +101,7 @@ public class Aptabase: NSObject {
 
     /// Forces all queued events to be sent to the server. Returns after the events have been sent.
     public func flush() async {
-        await self.client?.flush()
+        await client?.flush()
     }
 
     private func enqueueEvent(_ eventName: String, with props: [String: AnyCodableValue] = [:]) {


### PR DESCRIPTION
Fix for https://github.com/aptabase/aptabase-swift/issues/29. I think it makes sense to provide a `flush()` method that is `async` so I can perform something only after the events have been sent. There is currently no way to know when the events have been sent.