### PR TITLE
`EventDispatcher` should be an `Actor` to prevent concurrent access / mutation of `events`.

### DIFF
--- a/Sources/Aptabase/AptabaseClient.swift
+++ b/Sources/Aptabase/AptabaseClient.swift
@@ -41,7 +41,9 @@ class AptabaseClient {
                             deviceModel: env.deviceModel
                         ),
                         props: props)
-        dispatcher.enqueue(evt)
+        Task {
+            await dispatcher.enqueue(evt)
+        }
     }
 
     public func startPolling() {

--- a/Sources/Aptabase/AptabaseClient.swift
+++ b/Sources/Aptabase/AptabaseClient.swift
@@ -20,7 +20,14 @@ class AptabaseClient {
         dispatcher = EventDispatcher(appKey: appKey, baseUrl: baseUrl, env: env)
     }
 
+    /// Begins tracking an event in the asynchronously.
     public func trackEvent(_ eventName: String, with props: [String: AnyCodableValue] = [:]) {
+        Task {
+            await trackEvent(eventName, with: props)
+        }
+    }
+
+    public func trackEvent(_ eventName: String, with props: [String: AnyCodableValue] = [:]) async {
         let now = Date()
         if lastTouched.distance(to: now) > AptabaseClient.sessionTimeout {
             sessionId = AptabaseClient.newSessionId()
@@ -41,9 +48,8 @@ class AptabaseClient {
                             deviceModel: env.deviceModel
                         ),
                         props: props)
-        Task {
-            await dispatcher.enqueue(evt)
-        }
+
+        await dispatcher.enqueue(evt)
     }
 
     public func startPolling() {

--- a/Sources/Aptabase/EventDispatcher.swift
+++ b/Sources/Aptabase/EventDispatcher.swift
@@ -25,7 +25,7 @@ protocol URLSessionProtocol {
 
 extension URLSession: URLSessionProtocol {}
 
-public class EventDispatcher {
+public actor EventDispatcher {
     private var events = ConcurrentQueue<Event>()
     private let maximumBatchSize = 25
     private let headers: [String: String]

--- a/Tests/AptabaseTests/EventDispatcherTests.swift
+++ b/Tests/AptabaseTests/EventDispatcherTests.swift
@@ -48,15 +48,15 @@ final class EventDispatcherTests: XCTestCase {
     }
     
     func testFlushSingleItem() async {
-        dispatcher.enqueue(newEvent("app_started"))
-        
+        await dispatcher.enqueue(newEvent("app_started"))
+
         await dispatcher.flush()
         XCTAssertEqual(session.requestCount, 1)
     }
 
     func testFlushMultipleCalls() async {
         for i in 0...50 {
-            dispatcher.enqueue(newEvent("app_event_\(i)"))
+            await dispatcher.enqueue(newEvent("app_event_\(i)"))
         }
 
         await withTaskGroup { group in
@@ -70,10 +70,10 @@ final class EventDispatcherTests: XCTestCase {
     }
 
     func testFlushShouldBatchMultipleItems() async {
-        dispatcher.enqueue(newEvent("app_started"))
-        dispatcher.enqueue(newEvent("item_created"))
-        dispatcher.enqueue(newEvent("item_deleted"))
-        
+        await dispatcher.enqueue(newEvent("app_started"))
+        await dispatcher.enqueue(newEvent("item_created"))
+        await dispatcher.enqueue(newEvent("item_deleted"))
+
         await dispatcher.flush()
         XCTAssertEqual(session.requestCount, 1)
         
@@ -82,10 +82,10 @@ final class EventDispatcherTests: XCTestCase {
     }
     
     func testFlushShouldRetryAfterFailure() async {
-        dispatcher.enqueue(newEvent("app_started"))
-        dispatcher.enqueue(newEvent("item_created"))
-        dispatcher.enqueue(newEvent("item_deleted"))
-        
+        await dispatcher.enqueue(newEvent("app_started"))
+        await dispatcher.enqueue(newEvent("item_created"))
+        await dispatcher.enqueue(newEvent("item_deleted"))
+
         
         session.statusCode = 500
         await dispatcher.flush()

--- a/Tests/AptabaseTests/EventDispatcherTests.swift
+++ b/Tests/AptabaseTests/EventDispatcherTests.swift
@@ -53,7 +53,22 @@ final class EventDispatcherTests: XCTestCase {
         await dispatcher.flush()
         XCTAssertEqual(session.requestCount, 1)
     }
-    
+
+    func testFlushMultipleCalls() async {
+        for i in 0...50 {
+            dispatcher.enqueue(newEvent("app_event_\(i)"))
+        }
+
+        await withTaskGroup { group in
+            group.addTask { [self] in
+                await dispatcher.flush()
+            }
+            group.addTask { [self] in
+                await dispatcher.flush()
+            }
+        }
+    }
+
     func testFlushShouldBatchMultipleItems() async {
         dispatcher.enqueue(newEvent("app_started"))
         dispatcher.enqueue(newEvent("item_created"))


### PR DESCRIPTION
This should fix https://github.com/aptabase/aptabase-swift/issues/23 and https://github.com/aptabase/aptabase-swift/issues/25.

`EventDispatcher` `flush()` is called from multiple places at the same time (ex: from individual `Task`s when called from `stopPolling()`). This results in unsafe reads / mutations of `events`.

Added a test to reproduce the bug that I've been experiencing and that is the same as the two linked issues.

Appreciate any thoughts on this fix!