### PR TITLE
Added version option to optionals

### DIFF
--- a/Aptabase.podspec
+++ b/Aptabase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                      = 'Aptabase'
-    s.version                   = '0.3.11'
+    s.version                   = '0.3.12'
     s.summary                   = 'Swift SDK for Aptabase: Open Source, Privacy-First and Simple Analytics for Mobile, Desktop and Web Apps'
     s.homepage                  = 'https://aptabase.com'
     s.license                   = { :type => 'MIT', :file => 'LICENSE' }

--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ struct ExampleApp: App {
 }
 ```
 
+You can also pass options to customize behavior:
+
+```swift
+Aptabase.shared.initialize(appKey: "<YOUR_APP_KEY>", with: InitOptions(
+    host: "https://your-self-hosted-instance.com",  // For self-hosted Aptabase
+    flushInterval: 30,                               // Custom flush interval in seconds
+    trackingMode: .asRelease,                         // Force release mode
+    appVersion: "2.0.0"                               // Override the app version
+))
+```
+
+- `host` — Custom server URL for self-hosted Aptabase instances (required for `A-SH-*` app keys)
+- `flushInterval` — Interval in seconds for batching and sending events (default: automatic)
+- `trackingMode` — `.readFromEnvironment` (default), `.asDebug`, or `.asRelease`
+- `appVersion` — Override the app version reported with events (default: read from app bundle)
+
 Afterward, you can start tracking events with `trackEvent`:
 
 ```swift

--- a/Sources/Aptabase/Aptabase.swift
+++ b/Sources/Aptabase/Aptabase.swift
@@ -37,6 +37,10 @@ public class Aptabase: NSObject {
             env.isDebug = trackingMode.isDebug
         }
 
+        if let appVersion = options?.appVersion {
+            env.appVersion = appVersion
+        }
+
         client = AptabaseClient(appKey: appKey, baseUrl: baseUrl, env: env, options: options)
 
         let notifications = NotificationCenter.default

--- a/Sources/Aptabase/InitOptions.swift
+++ b/Sources/Aptabase/InitOptions.swift
@@ -5,14 +5,17 @@ public final class InitOptions: NSObject {
     let host: String?
     let flushInterval: Double?
     let trackingMode: TrackingMode
+    let appVersion: String?
 
     /// - Parameters:
     ///   - host: The custom host to use. If none provided will use Aptabase's servers.
     ///   - flushInterval: Defines a custom interval for flushing events.
     ///   - trackingMode: Use TrackingMode.asDebug for debug events, TrackingMode.asRelease for release events, or TrackingMode.readFromEnvironment to use the environment setting. Defaults to .readFromEnvironment if omitted.
-    @objc public init(host: String? = nil, flushInterval: NSNumber? = nil, trackingMode: TrackingMode = .readFromEnvironment) {
+    ///   - appVersion: Override the app version. If none provided will use the version from the app bundle.
+    @objc public init(host: String? = nil, flushInterval: NSNumber? = nil, trackingMode: TrackingMode = .readFromEnvironment, appVersion: String? = nil) {
         self.host = host
         self.flushInterval = flushInterval?.doubleValue
         self.trackingMode = trackingMode
+        self.appVersion = appVersion
     }
 }

--- a/llms.txt
+++ b/llms.txt
@@ -101,7 +101,8 @@ Pass `InitOptions` to customize behavior:
 let options = InitOptions(
     host: "https://your-self-hosted-instance.com",  // For self-hosted Aptabase
     flushInterval: 30,                               // Custom flush interval in seconds
-    trackingMode: .asRelease                          // Force release mode
+    trackingMode: .asRelease,                         // Force release mode
+    appVersion: "2.0.0"                               // Override the app version
 )
 Aptabase.shared.initialize(appKey: "<YOUR_APP_KEY>", with: options)
 ```
@@ -109,6 +110,7 @@ Aptabase.shared.initialize(appKey: "<YOUR_APP_KEY>", with: options)
 - `host` — Custom server URL for self-hosted Aptabase instances (required for `A-SH-*` app keys)
 - `flushInterval` — Interval in seconds for batching and sending events (default: automatic)
 - `trackingMode` — `.readFromEnvironment` (default), `.asDebug`, or `.asRelease`
+- `appVersion` — Override the app version reported with events (default: read from app bundle)
 
 To force-send queued events immediately:
 


### PR DESCRIPTION
When trying to setup my own app today using this great software, I came across the issue of beta testing. 

This sdk does not pull the value of the build number, so while the app is still in version 1, it is pretty bad for beta and alpha version testing, so ideally I want to be able to force my own app version to over-write the 1.0 build.

Let me know if this makes sense.